### PR TITLE
Fix lint errors

### DIFF
--- a/test/commands/issues/list-for-repo.test.js
+++ b/test/commands/issues/list-for-repo.test.js
@@ -35,7 +35,10 @@ describe('Octokit', () => {
 	// If this endpoint is not called, nock.isDone() will be false.
 	const successResponse = nock('https://api.github.com')
 		.get('/repos/Test-Owner/Test-Repo/issues')
-		.reply(200, [{ title: 'Test-Issue-01', created_at: 'Test-Date-01', html_url: 'Test-URL-01' }, { title: 'Test-Issue-02', created_at: 'Test-Date-02', html_url: 'Test-URL-02' }])
+		.reply(200, [
+			{ title: 'Test-Issue-01', created_at: 'Test-Date-01', html_url: 'Test-URL-01' },
+			{ title: 'Test-Issue-02', created_at: 'Test-Date-02', html_url: 'Test-URL-02' },
+		])
 
 	test('Running the command handler triggers a network request of the GitHub API', async () => {
 		await yargsModule.handler(yarguments)

--- a/test/commands/issues/list.test.js
+++ b/test/commands/issues/list.test.js
@@ -29,7 +29,10 @@ describe('Octokit', () => {
 	// If this endpoint is not called, nock.isDone() will be false.
 	const successResponse = nock('https://api.github.com')
 		.get('/issues?filter=assigned')
-		.reply(200, [{ title: 'Test-Issue-01', created_at: 'Test-Date-01', html_url: 'Test-URL-01' }, { title: 'Test-Issue-02', created_at: 'Test-Date-02', html_url: 'Test-URL-02' }])
+		.reply(200, [
+			{ title: 'Test-Issue-01', created_at: 'Test-Date-01', html_url: 'Test-URL-01' },
+			{ title: 'Test-Issue-02', created_at: 'Test-Date-02', html_url: 'Test-URL-02' },
+		])
 
 	test('Running the command handler triggers a network request of the GitHub API', async () => {
 		await yargsModule.handler(requiredArguments.options)


### PR DESCRIPTION
Fixes failing CI build caused by lint error: https://circleci.com/gh/Financial-Times/asari/663.

```
npm test

> asari@1.0.0 test /home/circleci/project/build-node-10
> npm run lint && npm run unit-test


> asari@1.0.0 lint /home/circleci/project/build-node-10
> eslint src/ bin/ test/


/home/circleci/project/build-node-10/test/commands/issues/list-for-repo.test.js
  38:16  error  Replace `{·title:·'Test-Issue-01',·created_at:·'Test-Date-01',·html_url:·'Test-URL-01'·},·{·title:·'Test-Issue-02',·created_at:·'Test-Date-02',·html_url:·'Test-URL-02'·}` with `⏎↹↹↹{·title:·'Test-Issue-01',·created_at:·'Test-Date-01',·html_url:·'Test-URL-01'·},⏎↹↹↹{·title:·'Test-Issue-02',·created_at:·'Test-Date-02',·html_url:·'Test-URL-02'·},⏎↹↹`  prettier/prettier

/home/circleci/project/build-node-10/test/commands/issues/list.test.js
  32:16  error  Replace `{·title:·'Test-Issue-01',·created_at:·'Test-Date-01',·html_url:·'Test-URL-01'·},·{·title:·'Test-Issue-02',·created_at:·'Test-Date-02',·html_url:·'Test-URL-02'·}` with `⏎↹↹↹{·title:·'Test-Issue-01',·created_at:·'Test-Date-01',·html_url:·'Test-URL-01'·},⏎↹↹↹{·title:·'Test-Issue-02',·created_at:·'Test-Date-02',·html_url:·'Test-URL-02'·},⏎↹↹`  prettier/prettier

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```